### PR TITLE
Fix: Improve color readability and uniqueness in themes

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,7 +5,7 @@
 :root {
   --background: 0 0% 100%;
   --foreground: 20 14.3% 4.1%;
-  --muted: 60 4.8% 95.9%;
+  --muted: 60 5% 94.5%;
   --muted-foreground: 25 5.3% 44.7%;
   --popover: 0 0% 100%;
   --popover-foreground: 20 14.3% 4.1%;
@@ -17,10 +17,10 @@
   --primary-foreground: 211 100% 99%;
   --secondary: 60 4.8% 95.9%;
   --secondary-foreground: 24 9.8% 10%;
-  --accent: 60 4.8% 95.9%;
+  --accent: 60 5.2% 93.0%;
   --accent-foreground: 24 9.8% 10%;
   --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 60 9.1% 97.8%;
+  --destructive-foreground: 60 9% 95.0%;
   --ring: 20 14.3% 4.1%;
   --radius: 0.5rem;
 
@@ -56,7 +56,7 @@
   --primary-foreground: 211 100% 99%;
   --secondary: 240 3.7% 15.9%;
   --secondary-foreground: 0 0% 98%;
-  --accent: 240 3.7% 15.9%;
+  --accent: 240 3.7% 14.5%;
   --accent-foreground: 0 0% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 0 0% 98%;


### PR DESCRIPTION
I've adjusted HSL color values in `client/src/index.css` for both light and dark themes to enhance text readability and ensure distinct visual values for semantically different UI elements.

Key changes:

Light Theme:
- I differentiated background colors for `--muted` and `--accent` from `--secondary` and each other by adjusting their lightness.
  - `--muted`: `60 4.8% 95.9%` -> `60 5% 94.5%`
  - `--accent`: `60 4.8% 95.9%` -> `60 5.2% 93.0%`
- I slightly darkened `--destructive-foreground` to improve its contrast on very light backgrounds.
  - `--destructive-foreground`: `60 9.1% 97.8%` -> `60 9% 95.0%`

Dark Theme:
- I differentiated `--accent` background from `--secondary` background by adjusting its lightness for consistency with the light theme strategy.
  - `--accent`: `240 3.7% 15.9%` -> `240 3.7% 14.5%`

These changes help prevent text from appearing the same color as its background in more scenarios and improve overall visual consistency and readability by ensuring that core semantic colors are not aliased to the exact same visual appearance.